### PR TITLE
Declare api-request dynamic in defn

### DIFF
--- a/src/happyapi/providers/google.clj
+++ b/src/happyapi/providers/google.clj
@@ -14,7 +14,7 @@
   See config/make-client for more options."
   [config] (set-request! (setup/make-client (when config {:google config}) :google)))
 
-(defn *api-request*
+(defn ^:dynamic *api-request*
   "A function to handle API requests.
   Can be configured with `setup!`.
   Will attempt to configure itself if not previously configured.


### PR DESCRIPTION
Re. #1 

This tiny PR gets rid of this warning. I think the other providers have it this way, just not the google one.

```
Warning: *api-request* not declared dynamic and thus is not dynamically rebindable, but its name suggests otherwise. Please either indicate ^:dynamic *api-request* or change the name. (happyapi/providers/google.clj:17)
```