### PR TITLE
Revert request as dynamic var

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ For Google APIs you can use the generated wrapper from the `happyapi.google` pro
 ```clojure
 (require '[happyapi.providers.google :as google])
 (require '[happyapi.google.youtube-v3 :as youtube])
-(google/*api-request* (youtube/channels-list "contentDetails,statistics" {:forUsername "ClojureTV"}))
+(google/api-request (youtube/channels-list "contentDetails,statistics" {:forUsername "ClojureTV"}))
 ```
 
 The generated wrapper constructs a request for `happyapi.providers.google/api-request`.
@@ -101,11 +101,11 @@ You can make custom, non-generated `api-requests` directly by passing the requir
 (google/setup! {:client_id     "XYZ"
                 :client_secret (System/getenv "GOOGLE_CLIENT_SECRET")
                 :deps          [:jetty :clj-http :cheshire]})
-(google/*api-request* {:method       :get
-                       :url          "https://youtube.googleapis.com/youtube/v3/channels"
-                       :query-params {:part        "contentDetails,statistics"
-                                      :forUsername "ClojureTV"}
-                       :scopes       ["https://www.googleapis.com/auth/youtube.readonly"]})
+(google/api-request {:method       :get
+                     :url          "https://youtube.googleapis.com/youtube/v3/channels"
+                     :query-params {:part        "contentDetails,statistics"
+                                    :forUsername "ClojureTV"}
+                     :scopes       ["https://www.googleapis.com/auth/youtube.readonly"]})
 ```
 
 **Keep your client_secret secure. Do not add it directly in your code.**

--- a/src/happyapi/providers/amazon.clj
+++ b/src/happyapi/providers/amazon.clj
@@ -1,10 +1,10 @@
 (ns happyapi.providers.amazon
   (:require [happyapi.setup :as setup]))
 
-(declare ^:dynamic *api-request*)
+(declare api-request)
 
 (defn set-request! [client]
-  (alter-var-root #'*api-request* (constantly client)))
+  (alter-var-root #'api-request (constantly client)))
 
 (defn setup!
   "Changes `api-request` to be a configured client.
@@ -14,7 +14,7 @@
   See config/make-client for more options."
   [config] (set-request! (setup/make-client (when config {:amazon config}) :amazon)))
 
-(defn ^:dynamic *api-request*
+(defn api-request
   "A function to handle API requests.
   Can be configured with `setup!`.
   Will attempt to configure itself if not previously configured.
@@ -23,10 +23,10 @@
   will be present in the generated interface."
   ([args]
    (setup! nil)
-   (*api-request* args))
+   (api-request args))
   ([args respond raise]
    (try
      (setup! nil)
-     (*api-request* args respond raise)
+     (api-request args respond raise)
      (catch Throwable ex
        (raise ex)))))

--- a/src/happyapi/providers/github.clj
+++ b/src/happyapi/providers/github.clj
@@ -1,10 +1,10 @@
 (ns happyapi.providers.github
   (:require [happyapi.setup :as setup]))
 
-(declare ^:dynamic *api-request*)
+(declare api-request)
 
 (defn set-request! [client]
-  (alter-var-root #'*api-request* (constantly client)))
+  (alter-var-root #'api-request (constantly client)))
 
 (defn setup!
   "Changes `api-request` to be a configured client.
@@ -14,7 +14,7 @@
   See config/make-client for more options."
   [config] (set-request! (setup/make-client (when config {:github config}) :github)))
 
-(defn ^:dynamic *api-request*
+(defn api-request
   "A function to handle API requests.
   Can be configured with `setup!`.
   Will attempt to configure itself if not previously configured.
@@ -23,10 +23,10 @@
   will be present in the generated interface."
   ([args]
    (setup! nil)
-   (*api-request* args))
+   (api-request args))
   ([args respond raise]
    (try
      (setup! nil)
-     (*api-request* args respond raise)
+     (api-request args respond raise)
      (catch Throwable ex
        (raise ex)))))

--- a/src/happyapi/providers/google.clj
+++ b/src/happyapi/providers/google.clj
@@ -1,10 +1,10 @@
 (ns happyapi.providers.google
   (:require [happyapi.setup :as setup]))
 
-(declare ^:dynamic *api-request*)
+(declare api-request)
 
 (defn set-request! [client]
-  (alter-var-root #'*api-request* (constantly client)))
+  (alter-var-root #'api-request (constantly client)))
 
 (defn setup!
   "Changes `api-request` to be a configured client.
@@ -14,7 +14,7 @@
   See config/make-client for more options."
   [config] (set-request! (setup/make-client (when config {:google config}) :google)))
 
-(defn ^:dynamic *api-request*
+(defn api-request
   "A function to handle API requests.
   Can be configured with `setup!`.
   Will attempt to configure itself if not previously configured.
@@ -23,10 +23,10 @@
   will be present in the generated interface."
   ([args]
    (setup! nil)
-   (*api-request* args))
+   (api-request args))
   ([args respond raise]
    (try
      (setup! nil)
-     (*api-request* args respond raise)
+     (api-request args respond raise)
      (catch Throwable ex
        (raise ex)))))

--- a/src/happyapi/providers/twitter.clj
+++ b/src/happyapi/providers/twitter.clj
@@ -1,10 +1,10 @@
 (ns happyapi.providers.twitter
   (:require [happyapi.setup :as setup]))
 
-(declare ^:dynamic *api-request*)
+(declare api-request)
 
 (defn set-request! [client]
-  (alter-var-root #'*api-request* (constantly client)))
+  (alter-var-root #'api-request (constantly client)))
 
 (defn setup!
   "Changes `api-request` to be a configured client.
@@ -14,7 +14,7 @@
   See config/make-client for more options."
   [config] (set-request! (setup/make-client (when config {:twitter config}) :twitter)))
 
-(defn ^:dynamic *api-request*
+(defn api-request
   "A function to handle API requests.
   Can be configured with `setup!`.
   Will attempt to configure itself if not previously configured.
@@ -23,10 +23,10 @@
   will be present in the generated interface."
   ([args]
    (setup! nil)
-   (*api-request* args))
+   (api-request args))
   ([args respond raise]
    (try
      (setup! nil)
-     (*api-request* args respond raise)
+     (api-request args respond raise)
      (catch Throwable ex
        (raise ex)))))

--- a/test/happyapi/providers/github_test.clj
+++ b/test/happyapi/providers/github_test.clj
@@ -4,7 +4,7 @@
 
 (deftest api-request-test
   (github/setup! nil)
-  (is (-> (github/*api-request* {:method :get
+  (is (-> (github/api-request {:method :get
                                :url      "https://api.github.com/user"
                                :scopes   ["user" "user:email"]})
           (get "email"))))

--- a/test/happyapi/providers/google_test.clj
+++ b/test/happyapi/providers/google_test.clj
@@ -4,7 +4,7 @@
 
 (deftest api-request-test
   (google/setup! nil)
-  (let [channels (google/*api-request* {:method     :get
+  (let [channels (google/api-request {:method     :get
                                       :url          "https://youtube.googleapis.com/youtube/v3/channels"
                                       :query-params {:part        "contentDetails,statistics"
                                                      :forUsername "ClojureTV"}

--- a/test/happyapi/providers/twitter_test.clj
+++ b/test/happyapi/providers/twitter_test.clj
@@ -4,16 +4,16 @@
 
 (deftest api-request-test
   (twitter/setup! nil)
-  (is (-> (twitter/*api-request* {:method  :get
+  (is (-> (twitter/api-request {:method  :get
                                    :url    "https://api.twitter.com/2/users/me"
                                    :scopes ["tweet.read" "tweet.write" "users.read"]})
           (get "username")))
-  (is (-> (twitter/*api-request* {:method :delete
+  (is (-> (twitter/api-request {:method :delete
                                 :url      "https://api.twitter.com/2/tweets/1811986925798195513"
                                 :scopes   ["tweet.read" "tweet.write" "users.read"]})
           (get "deleted")))
   ;; let's not post every time I run the tests...
-  #_(twitter/*api-request* {:method :post
+  #_(twitter/api-request {:method :post
                           :url      "https://api.twitter.com/2/tweets"
                           :scopes   ["tweet.read" "tweet.write" "users.read"]
                           :body     {:text "This is a test tweet from HappyAPI"}}))


### PR DESCRIPTION
Generated libraries now return data, so request does not need to be a dynamic var anymore.