### PR TITLE
Allow localhost https.

### DIFF
--- a/src/happyapi/oauth2/capture_redirect.clj
+++ b/src/happyapi/oauth2/capture_redirect.clj
@@ -38,7 +38,7 @@
   and include_granted_scopes true."
   [request {:as config :keys [redirect_uri authorization_options fns]} scopes]
   (let [p (promise)
-        [match protocol host _ requested-port path] (re-find #"^(http://)(localhost|127.0.0.1)(:(\d+))?(/.*)?$" redirect_uri)
+        [match protocol host _ requested-port path] (re-find #"^(https?://)(localhost|127.0.0.1)(:(\d+))?(/.*)?$" redirect_uri)
         _ (when-not match
             (throw (ex-info "redirect_uri should match http://localhost"
                             {:id           ::bad-redirect-uri

--- a/test/happyapi/oauth2/capture_redirect_test.clj
+++ b/test/happyapi/oauth2/capture_redirect_test.clj
@@ -1,5 +1,6 @@
 (ns happyapi.oauth2.capture-redirect-test
   (:require [clojure.test :refer [deftest is testing]]
+            [clojure.string :as str]
             [happyapi.deps :as deps]
             [happyapi.oauth2.capture-redirect :as capture-redirect]
             [happyapi.oauth2.auth :as auth]
@@ -7,7 +8,8 @@
 
 (deftest wait-for-redirect-test
   (with-redefs [capture-redirect/browse-to-provider (fn browse-to-provider [{:as config :keys [redirect_uri]} scopes optional]
-                                                      (http/get (str redirect_uri "?code=CODE&state=" (:state optional))))
+                                                      (http/get (str (str/replace redirect_uri "https" "http")
+                                                                     "?code=CODE&state=" (:state optional))))
                 auth/exchange-code (fn exhange-code [request config code challenge]
                                      (is (= "CODE" code))
                                      {:access_token "TOKEN"})]
@@ -18,6 +20,14 @@
       (is (= {:access_token "TOKEN"}
              (capture-redirect/fresh-credentials http/request
                                                  (assoc config :redirect_uri "http://localhost")
+                                                 [])))
+      (is (= {:access_token "TOKEN"}
+             (capture-redirect/fresh-credentials http/request
+                                                 (assoc config :redirect_uri "http://127.0.0.1")
+                                                 [])))
+      (is (= {:access_token "TOKEN"}
+             (capture-redirect/fresh-credentials http/request
+                                                 (assoc config :redirect_uri "https://localhost")
                                                  [])))
       (is (= {:access_token "TOKEN"}
              (capture-redirect/fresh-credentials http/request


### PR DESCRIPTION
Some providers insist on the redirect URL being HTTPS, even for localhost.
This PR enables that.