### PR TITLE
require just some scopes instead of all scopes

### DIFF
--- a/src/happyapi/oauth2/auth.clj
+++ b/src/happyapi/oauth2/auth.clj
@@ -145,8 +145,19 @@
   (boolean (or refresh_token private_key)))
 
 (defn credential-scopes [credentials]
-  (set (some-> (:scope credentials) (str/split #" "))))
+  (set (some-> credentials
+               :scope
+               (str/split #" "))))
 
-(defn has-scopes? [credentials scopes]
-  ;; TODO: scopes have a hierarchy
-  (set/subset? (set scopes) (credential-scopes credentials)))
+(defn has-some-scope?
+  "Test if any of the sufficient scopes is present in the token.
+
+  While scopes in APIs can have a hierarchy,
+  all sufficient scopes for an API need to be listed explicitly.
+
+  E.g. Google's discovery docs follow that rule and list all possible scopes.
+  whenever you see a https://www.googleapis.com/auth/spreadsheets.readonly scope,
+  the more powerful https://www.googleapis.com/auth/spreadsheets scope will be listed, too."
+  [credentials scopes]
+  (not (empty? (set/intersection (set scopes)
+                                 (credential-scopes credentials)))))

--- a/src/happyapi/oauth2/capture_redirect.clj
+++ b/src/happyapi/oauth2/capture_redirect.clj
@@ -100,11 +100,11 @@
             (or
               ;; already have valid credentials
               (and (oauth2/valid? credentials)
-                   (oauth2/has-scopes? credentials scopes)
+                   (oauth2/has-some-scope? credentials scopes)
                    credentials)
               ;; try to refresh existing credentials
               (and (oauth2/refreshable? config credentials)
-                   (oauth2/has-scopes? credentials scopes)
+                   (oauth2/has-some-scope? credentials scopes)
                    (oauth2/refresh-credentials (middleware/wrap-keywordize-keys request true) config scopes credentials))
               ;; new credentials required
               (fresh-credentials (middleware/wrap-keywordize-keys request true) config scopes))))))

--- a/test/happyapi/oauth2/auth_test.clj
+++ b/test/happyapi/oauth2/auth_test.clj
@@ -31,3 +31,13 @@
           (is credentials)
           (is (middleware/success? (auth/revoke-token request config credentials)))
           (credentials/delete-credentials provider "user"))))))
+
+(deftest scopes-test
+  (is (= true (auth/has-some-scope? {:scope "a b c"}
+                                    ["d" "e" "a"])))
+  (is (= false (auth/has-some-scope? {:scope "a b c"}
+                                     ["d" "e" "f"])))
+  (is (= false (auth/has-some-scope? {}
+                                     ["d" "e" "f"])))
+  (is (= false (auth/has-some-scope? {:scope "a b c"}
+                                     []))))


### PR DESCRIPTION
I adjusted the check for scopes in tokens to just check for the presence of any required scope, not for the presence of all scopes. 